### PR TITLE
bugfix(css-blipchat): removing visibility property in css file to fix reopen bug in ios14

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -42,7 +42,6 @@ $maxHeight: 420px;
     bottom: 90px;
     right: 38px;
     opacity: 0;
-    visibility: hidden;
     transition: opacity 500ms, transform 500ms, visibility 500ms, height 0s 500ms;
     transform: translateY(10%);
     z-index: 1;


### PR DESCRIPTION
Removing blip chat iframe 'visibility' property to fix a bug in newest iOS version (14) 