### PR TITLE
feat(BlipChat): Add support for custom search parameters in iframe URL

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,153 @@
+# Blip Chat Widget - AI Coding Agent Instructions
+
+## Project Overview
+This is a standalone JavaScript widget library for embedding BLiP chatbots into websites. It's distributed as a UMD module via unpkg CDN and npm. The widget creates an iframe-based chat UI with a floating action button, communicating with BLiP's hosted chat service via postMessage API.
+
+## Architecture
+
+### Two-Component System
+- **`BlipChat.js`**: Public API with builder pattern (`.withAppKey()`, `.withButton()`, etc.) - this is what developers interact with
+- **`BlipChatWidget.js`**: Core implementation that manages iframe lifecycle, postMessage communication, and DOM manipulation
+
+### Communication Flow
+1. Widget creates iframe pointing to `chat.blip.ai` (or custom URL via `withCustomCommonUrl`)
+2. PostMessage codes (defined in `Constants.js`) coordinate bidirectional communication:
+   - Widget → iframe: `START_CONNECTION_CODE`, `SEND_MESSAGE_CODE`, `CUSTOM_STYLE_CODE`
+   - iframe → Widget: `CHAT_READY_CODE`, `CREATE_ACCOUNT_CODE`, `PARENT_NOTIFICATION_CODE`
+3. All data passed through iframe boundary is base64-encoded for security
+
+### Authentication Patterns
+Two auth types (see `Constants.js`):
+- **Guest**: Auto-generates UUID identity, stores in localStorage for 30 days (see `StorageService.js`)
+- **Dev**: Requires `userIdentity` + `userPassword`, encodes as `${identity}.${botIdentifier}`
+
+## Development Workflows
+
+### Local Development
+```bash
+npm start:local    # Points to localhost:8082 (requires local chat service)
+npm start          # Points to HMG environment
+npm start:prod     # Points to production
+```
+Open `http://localhost:3000` - the `index.html` is a full sandbox with auth/connection/messaging tests.
+
+### Build & Release
+```bash
+npm run build      # Production build → dist/blip-chat.js (uglified)
+npm run build:hmg  # HMG build (points to staging)
+```
+Releases automated via semantic-release on Azure Pipelines (see `azure-pipelines.yml`). Uses conventional commits (`npm run commit` for commitizen).
+
+## Critical Patterns
+
+### Environment URL Configuration
+URLs are **not** dynamically changed - they're baked into webpack build via `process.env.NODE_ENV`:
+- `production` → `https://chat.blip.ai/`
+- `homolog` → `https://hmg-chat.blip.ai/`
+- `local` → `http://localhost:8082/`
+
+Override with `withCustomCommonUrl()` for organization-specific BLiP instances.
+
+### Widget vs Embedded Mode
+- **Widget mode** (default): Creates floating button, append to `body`
+- **Target mode**: Call `.withTarget('element-id')` - embeds inline, no floating button
+
+Check distinction in `BlipChatWidget.js:_onInit()` - `if (!self.target)` branches control this.
+
+### Storage & Persistence
+`StorageService.js` implements expiring localStorage:
+- Values stored as base64 JSON with `expires` timestamp
+- `processLocalStorageExpires()` runs on init to clean expired items
+- Used for Guest auth persistence (30 days = `2.592e+9` ms)
+
+### Message Queueing
+If `sendMessage()` or `sendCommand()` called before iframe loads, they're queued in `self.pendings[]` and flushed on `CHAT_CONNECTED_CODE` (see `BlipChatWidget.js:_onReceivePostMessage`).
+
+### Notification System
+`NotificationHandler.js` uses Observable pattern:
+- Tracks messages when chat closed
+- Blinks document title when tab hidden
+- Updates badge count on floating button
+- Cleared when chat opened
+
+### Responsive Fullscreen Detection
+`_checkFullScreen()` monitors viewport ≤480px or ≤420px height to:
+- Toggle fullscreen iframe mode
+- Show/hide close button via `SHOW_CLOSE_BUTTON` postMessage
+
+## Common Modifications
+
+### Adding New Builder Methods
+1. Add property to `BlipChat.js` constructor
+2. Create `withX(value)` method returning `this`
+3. Pass to `BlipChatWidget` constructor
+4. Handle in widget's init or send via postMessage
+
+Example: The `withCustomSearchParams()` method allows passing custom query parameters to the iframe URL. Parameters are URL-encoded and appended in `_setChatUrlEnvironment()`.
+
+### New PostMessage Codes
+1. Define constant in `Constants.js`
+2. Add case in `BlipChatWidget.js:_onReceivePostMessage()`
+3. For widget→iframe, create helper using `_sendPostMessage()`
+
+### Custom Styling
+Injected via `CUSTOM_STYLE_CODE` postMessage after `CHAT_READY_CODE`. Styles applied inside iframe, not widget container. See `index.html` for comprehensive example.
+
+## Dependencies & Build
+
+### Key Dependencies
+- **babel-polyfill**: Required for IE11 support (loaded conditionally)
+- **uuid**: Generates guest user identities
+- **webpack 3**: Builds UMD bundle with dev server hot reload
+- **sass-loader**: Compiles `styles/main.scss` to CSS
+
+### Webpack Specifics
+- Entry: `src/BlipChat.js` (exports `BlipChat` class)
+- Output: UMD module exports to `window.BlipChat`
+- Images/SVGs inlined via url-loader (<8KB)
+- HTML template (`chat.html`) inlined via html-loader
+
+## Testing & Debugging
+
+No automated tests currently (`"test": "echo \"Error: no test specified\" && exit 1"`).
+
+**Manual testing**: Use `index.html` sandbox:
+- Test both auth types (Guest/Dev)
+- Test widget vs target mode (toggle with "Change SDK Template")
+- Test message/command sending
+- Test custom styles and connection data
+
+**Browser Console**: Widget exposes methods on instance:
+```javascript
+const chat = new BlipChat().withAppKey('...').build();
+chat.sendMessage({ type: "text/plain", content: "test" });
+chat.toogleChat();  // Note: typo in original - should be "toggle"
+chat.destroy();
+```
+
+## Known Quirks
+
+- **Typo**: `toogleChat()` should be `toggleChat()` - maintain for backward compatibility
+- **HTTPS Required**: Geolocation cards need HTTPS, some browsers block mixed content
+- **CSP**: Host sites must allow `frame-src https://chat.blip.ai/`
+- **Referrer-Policy**: Cannot use `no-referrer` or `same-origin` - widget needs `document.referrer`
+- **Window protocol**: URLs converted with `_getNewUrlWithWebProtocol()` to match `http/https`
+
+## File Organization
+
+```
+src/
+  BlipChat.js              # Public API (builder pattern)
+  BlipChatWidget.js        # Core widget logic
+  utils/
+    Constants.js           # PostMessage codes & URLs
+    StorageService.js      # Expiring localStorage wrapper
+    NotificationHandler.js # Badge & title notifications
+    Observable.js          # Simple pub-sub for notifications
+    Misc.js                # UUID generation, DOM helpers
+  static/chat.html         # Widget button template
+  styles/main.scss         # Widget container styles
+  images/                  # SVG icons (inlined)
+```
+
+Focus changes in `BlipChat.js` or `BlipChatWidget.js` - utils are stable helpers.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ new BlipChat()
 | withTarget        | Set the element that will contain the chat              |
 | withCustomStyle   | Set a custom style for BLiP Chat                        |
 | withCustomCommonUrl   | Set a custom URL for BLiP Chat                      |
+| withCustomSearchParams | Set custom query parameters for the iframe URL     |
 
 *Guest auth will keep the same generated 'userIdentity' for 30 days. When using DEV auth type, 'userIdentity' and 'userPassword' are required.
 
@@ -171,6 +172,29 @@ Connect on BLiP Chat with a custom URL. Specifying how to use organizations in B
           var blipClient = new BlipChat()
           .withAppKey('YOUR-APP-KEY')
           .withCustomCommonUrl('https://take.chat.blip.ai/'); // Add the organization BLiP Chat URL here
+
+          blipClient.build();
+        }
+    })();
+</script>
+```
+
+## Example 5
+
+Connect on BLiP Chat with custom search parameters. Add additional query parameters to the iframe URL.
+
+```js
+<script src="https://unpkg.com/blip-chat-widget@1.11.*" type="text/javascript"></script>
+<script>
+    (function () {
+        window.onload = function () {
+          var blipClient = new BlipChat()
+          .withAppKey('YOUR-APP-KEY')
+          .withCustomSearchParams({
+            param1: 'value1',
+            param2: 'value2',
+            userId: '12345'
+          }); // Adds &param1=value1&param2=value2&userId=12345 to the iframe URL
 
           blipClient.build();
         }

--- a/index.html
+++ b/index.html
@@ -29,6 +29,10 @@
             value="production"
           />
 
+          <!-- started selected -->
+          <input type="checkbox" id="hideWelcome" name="hideWelcome" />
+          <label for="hideWelcome">Hide Welcome Message</label>
+
           <p>Use buttons bellow to see different behaviours of BLiP Chat</p>
 
           <button onclick="buildChat({authType:BlipChat.GUEST_AUTH})">
@@ -159,6 +163,7 @@
             const environment = document.getElementById('environment').value
               ? document.getElementById('environment').value
               : 'homolog'
+            const hideWelcomeValue = document.getElementById('hideWelcome').checked;
             const appKey =
               document.getElementById('app-key').value ||
               'YmxpcHRlc3RjYXJkczo3YTcwZTUyNi04YzNjLTRmNGQtYWZjYi00ZWFmNzk5ZDFmNjk='
@@ -224,6 +229,9 @@
                 encryptMessageContent: true
               })
               .withCustomStyle(customStyle)
+              .withCustomSearchParams({
+                hideWelcome: hideWelcomeValue,
+              })
               .withEventHandler(BlipChat.ENTER_EVENT, function() {
                 console.log('enter')
               })

--- a/src/BlipChat.js
+++ b/src/BlipChat.js
@@ -100,6 +100,11 @@ export class BlipChat {
     return this
   }
 
+  withCustomSearchParams(params) {
+    this.customSearchParams = params
+    return this
+  }
+
   withoutHistory() {
     this.disableHistory = true
     return this
@@ -118,7 +123,8 @@ export class BlipChat {
       this.customMessageMetadata,
       this.customCommonUrl,
       this.connectionData || {},
-      this.disableHistory || false
+      this.disableHistory || false,
+      this.customSearchParams || {}
     )
   }
 

--- a/src/BlipChatWidget.js
+++ b/src/BlipChatWidget.js
@@ -38,7 +38,8 @@ export class BlipChatWidget {
     customMessageMetadata,
     customCommonUrl,
     connectionData,
-    disableHistory
+    disableHistory,
+    customSearchParams
   ) {
     self = this
     self.appKey = appKey
@@ -60,6 +61,7 @@ export class BlipChatWidget {
     self.customCommonUrl = customCommonUrl
     self.connectionData = connectionData
     self.disableHistory = disableHistory
+    self.customSearchParams = customSearchParams
 
     self._setChatUrlEnvironment(environment, authConfig, appKey)
 
@@ -119,6 +121,13 @@ export class BlipChatWidget {
 
     self.CHAT_URL += `?appKey=${encodeURIComponent(appKey)}`
     if (authConfig) self.CHAT_URL += `&authType=${authConfig.authType}`
+
+    // Append custom search parameters if provided
+    if (self.customSearchParams) {
+      Object.keys(self.customSearchParams).forEach((key) => {
+        self.CHAT_URL += `&${encodeURIComponent(key)}=${encodeURIComponent(self.customSearchParams[key])}`
+      })
+    }
   }
 
   _resizeElements() {


### PR DESCRIPTION
https://github.com/user-attachments/assets/59c201c9-4d54-4bba-b9e7-4602eb799e62

This pull request introduces a new feature that allows developers to pass custom query parameters to the BLiP Chat iframe URL via the `withCustomSearchParams()` builder method. The feature is documented in both the code and user-facing documentation, and is demonstrated in the sandbox (`index.html`). The implementation ensures that any custom parameters provided are appended to the chat iframe URL during initialization, allowing for greater flexibility and customization in embedding the chat widget.

**New Feature: Custom Search Parameters**
- Added `withCustomSearchParams(params)` builder method to `BlipChat.js`, enabling developers to specify custom query parameters for the chat iframe URL.
- Updated `BlipChatWidget.js` to accept and handle `customSearchParams`, appending them to the iframe URL in `_setChatUrlEnvironment()`. [[1]](diffhunk://#diff-12dcc323352d449f4727727c94b822625b901b20456915533761eff06d82c7a3L41-R42) [[2]](diffhunk://#diff-12dcc323352d449f4727727c94b822625b901b20456915533761eff06d82c7a3R64) [[3]](diffhunk://#diff-12dcc323352d449f4727727c94b822625b901b20456915533761eff06d82c7a3R124-R130)

**Documentation Updates**
- Added documentation for `withCustomSearchParams` to the public API table in `README.md`.
- Provided an example usage of the new method in `README.md`, showing how to add custom parameters to the iframe URL.
- Included a comprehensive architectural and usage overview in `.github/copilot-instructions.md`, describing the new builder method and its integration points.

**Sandbox and Demo Improvements**
- Updated `index.html` sandbox to demonstrate the new feature, including a checkbox to hide the welcome message by passing `hideWelcome` as a custom search parameter. [[1]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R32-R35) [[2]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R166) [[3]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R232-R234)


